### PR TITLE
add unistd.h include to files using usleep

### DIFF
--- a/src/debug-core/targetsilabs.cpp
+++ b/src/debug-core/targetsilabs.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <pthread.h>
 #include <stdio.h>
+#include <unistd.h>
 #include "targetsilabs.h"
 #include "ec2drv.h"
 

--- a/src/ec2tools/ec2test-any.cpp
+++ b/src/ec2tools/ec2test-any.cpp
@@ -24,6 +24,7 @@
 #include <signal.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <unistd.h>
 #include "ec2drv.h"
 using namespace std;
 


### PR DESCRIPTION
On my system the build fails when trying to use usleep without
include <unistd.h>

This patch adds the include.
