### PR TITLE
Fix python version, causing error during compilation.

### DIFF
--- a/src/ec2drv/csv2c.py
+++ b/src/ec2drv/csv2c.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python3
 # cvs2c
 # csv converter for devices table to c table
 #


### PR DESCRIPTION
Fixes the following issue. 

```
$ make
make  all-recursive
make[1]: Entering directory '/home/kaklik/Downloads/ec2-new'
Making all in src
make[2]: Entering directory '/home/kaklik/Downloads/ec2-new/src'
Making all in ec2drv
make[3]: Entering directory '/home/kaklik/Downloads/ec2-new/src/ec2drv'
./csv2c.py -i ./device_table.csv \
-c ./device_table.c \
-e ./device_enum.h
/bin/bash: ./csv2c.py: /usr/bin/python: bad interpreter: No such file or directory
make[3]: *** [Makefile:717: device_table.c] Error 126
make[3]: Leaving directory '/home/kaklik/Downloads/ec2-new/src/ec2drv'
make[2]: *** [Makefile:358: all-recursive] Error 1
make[2]: Leaving directory '/home/kaklik/Downloads/ec2-new/src'
make[1]: *** [Makefile:407: all-recursive] Error 1
make[1]: Leaving directory '/home/kaklik/Downloads/ec2-new'
make: *** [Makefile:339: all] Error 2

```